### PR TITLE
Precompile bash shellenv output and ability to toggle alias definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 *.zwc
 *.zwc.old
+_brew.zsh

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 homebrew
 ========
 
-Defines Homebrew aliases.
+[zim-module](https://github.com/zimfw/zimfw) for [homebrew](https://brew.sh/).
 
-Also adds the Homebrew-managed `zsh/site-functions` path into your `fpath`.
+To ensure that subsequent modules, which rely on binaries added via Homebrew, operate as intended, load the Homebrew module at the beginning of your `.zimrc` file.
+After including the module, you can safely discard the Homebrew evaluation call from your .zshrc file.
 
-Aliases
--------
+## Features
+
+- Defines Homebrew aliases.
+- Adds the Homebrew-managed `zsh/site-functions` path into your `fpath`.
+- Pre-compiles the `brew shellenv` command to eliminate recurring eval calls.
+
+## Aliases
+
+The alias definitions can be disabled by setting the variable `ZIM_HOMEBREW_ALIASES` to `false`.
 
 ### Homebrew
 

--- a/init.zsh
+++ b/init.zsh
@@ -1,42 +1,68 @@
+# Try to find brew binary
+if (( ${+commands[brew]} )); then
+  local _homebrew_binary="${commands[brew]}"
+else
+  local _homebrew_paths=("/opt/homebrew" "/usr/local" "/home/linuxbrew/.linuxbrew")
+  for _homebrew_path in $_homebrew_paths
+  do
+    if [[ -x "${_homebrew_path}/bin/brew" ]] then
+      local _homebrew_binary="${_homebrew_path}/bin/brew"
+      break
+    fi
+  done
+fi
+
 # Ensure brew is available
-if (( ! ${+commands[brew]} )); then
+if (( ! ${+_homebrew_path} )); then
   return 1
 fi
 
+
+if (( ! ${+ZIM_HOMEBREW_ALIASES} )) typeset -g ZIM_HOMEBREW_ALIASES=true
+
 fpath=(/opt/homebrew/share/zsh/site-functions(N) /home/linuxbrew/.linuxbrew/share/zsh/site-functions(N) ${fpath})
+
+local _plugin_dir="${0:A:h}"
+
+${_homebrew_binary} shellenv >| ${_plugin_dir}/_brew.zsh
+source ${_plugin_dir}/_brew.zsh
 
 #
 # Aliases
 #
 
-# Homebrew
-alias brewa='brew autoremove'
-alias brewc='brew cleanup'
-alias brewC='brew cleanup -s'
-alias brewd='brew doctor --verbose'
-alias brewe='brew edit --formula'
-alias brewi='brew info --formula'
-alias brewI='brew install --formula'
-alias brewl='brew list --formula'
-alias brewL='brew leaves'
-alias brewo='brew outdated --formula'
-alias brewr='brew reinstall --formula'
-alias brews='brew search --formula'
-alias brewS='brew services'
-alias brewu='brew update'
-alias brewU='brew upgrade --formula --ignore-pinned'
-alias brewx='brew uninstall --formula'
-alias brewX='brew uninstall --formula --force'
+if [[ ${ZIM_HOMEBREW_ALIASES} = true ]]; then
+  # Homebrew
+  alias brewa='brew autoremove'
+  alias brewc='brew cleanup'
+  alias brewC='brew cleanup -s'
+  alias brewd='brew doctor --verbose'
+  alias brewe='brew edit --formula'
+  alias brewi='brew info --formula'
+  alias brewI='brew install --formula'
+  alias brewl='brew list --formula'
+  alias brewL='brew leaves'
+  alias brewo='brew outdated --formula'
+  alias brewr='brew reinstall --formula'
+  alias brews='brew search --formula'
+  alias brewS='brew services'
+  alias brewu='brew update'
+  alias brewU='brew upgrade --formula --ignore-pinned'
+  alias brewx='brew uninstall --formula'
+  alias brewX='brew uninstall --formula --force'
 
-# Homebrew Cask
-alias caske='brew edit --cask'
-alias caski='brew info --cask'
-alias caskI='brew install --cask'
-alias caskl='brew list --cask'
-alias casko='brew outdated --cask'
-alias caskr='brew reinstall --cask'
-alias casks='brew search --cask'
-alias caskU='brew upgrade --cask'
-alias caskx='brew uninstall --cask'
-alias caskX='brew uninstall --cask --force'
-alias caskz='brew uninstall --cask --zap'
+  # Homebrew Cask
+  alias caske='brew edit --cask'
+  alias caski='brew info --cask'
+  alias caskI='brew install --cask'
+  alias caskl='brew list --cask'
+  alias casko='brew outdated --cask'
+  alias caskr='brew reinstall --cask'
+  alias casks='brew search --cask'
+  alias caskU='brew upgrade --cask'
+  alias caskx='brew uninstall --cask'
+  alias caskX='brew uninstall --cask --force'
+  alias caskz='brew uninstall --cask --zap'
+fi
+
+unset _homebrew_paths _homebrew_path _plugin_dir


### PR DESCRIPTION
This change adds two new features:

1. Allow toggling of the alias definitions, Personally I do not have a need for them and they would pollute my autocompletion suggestions.
2. Precompile the brew shell env output, removing the need to add customizations to the `.zshrc` file when this plugin is loaded and avoiding `eval` calls.